### PR TITLE
Nutze 4 Spalten im Footer

### DIFF
--- a/frontend/src/app/components/global/footer/footer.component.css
+++ b/frontend/src/app/components/global/footer/footer.component.css
@@ -14,7 +14,7 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
 
-    max-width: 75%;
+    max-width: 80%;
     margin-left: auto;
     margin-right: auto;
 }


### PR DESCRIPTION
Nutze 4 Spalten im Footer

| Zuvor | Danach |
| ----- | ------ |
| <img width="1470" height="804" alt="image" src="https://github.com/user-attachments/assets/0cc5cdf8-9b97-4964-a1ad-d0c233f353d9" /> | <img width="1918" height="398" alt="image" src="https://github.com/user-attachments/assets/920356e2-1b01-4fc4-a0c2-0d4af8c085ef" /> |